### PR TITLE
refactor: update deprecated task identifiers in examples

### DIFF
--- a/src/main/java/io/kestra/plugin/flink/MonitorJob.java
+++ b/src/main/java/io/kestra/plugin/flink/MonitorJob.java
@@ -62,7 +62,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: notify-completion
-                    type: io.kestra.core.tasks.log.Log
+                    type: io.kestra.plugin.core.log.Log
                     message: "Flink job {{ trigger.jobId }} reached state: {{ trigger.finalState }}"
                 """
         )


### PR DESCRIPTION
Update the old task names in the examples to the current ones.